### PR TITLE
feat: add multi-select batch upgrade on Upgrades tab

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -92,6 +92,7 @@ pub enum Operation {
     Install { id: String, version: Option<String> },
     Uninstall { id: String },
     Upgrade { id: String },
+    BatchUpgrade { ids: Vec<String> },
 }
 
 impl fmt::Display for Operation {
@@ -106,6 +107,7 @@ impl fmt::Display for Operation {
             }
             Self::Uninstall { id } => write!(f, "Uninstalling {id}"),
             Self::Upgrade { id } => write!(f, "Upgrading {id}"),
+            Self::BatchUpgrade { ids } => write!(f, "Batch upgrading {} packages", ids.len()),
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds the ability to select multiple packages on the Upgrades tab and upgrade them all at once.

## New Keybindings (Upgrades tab only)

| Key | Action |
|-----|--------|
| **Space** | Toggle select/deselect current package |
| **a** | Select all / deselect all |
| **U** (Shift+U) | Batch upgrade all selected packages |

## What Changed

- **models.rs**: Added BatchUpgrade variant to Operation enum
- **app.rs**: Added selected_packages HashSet, StatusUpdate message for progress, sequential batch execution logic
- **handler.rs**: Space/a/U key handlers, selection clearing on tab switch
- **ui.rs**: Checkbox indicators, selection count in title bar, batch action hints in detail panel, updated help overlay

## Design Decisions

- **Sequential execution**: Upgrades run one-by-one to avoid Windows Installer mutex conflicts
- **Live progress**: Status bar shows "Upgrading 2/5: PackageName..." during batch
- **Partial failure handling**: Reports "N/M succeeded, K failed" with details
- **Selection safety**: Selections auto-clear on tab switch, filter change, or data reload (indices become stale)
- **IDs snapshotted at confirm time**: The batch uses package IDs captured when you press U, not indices, so it's safe even if the list refreshes

## Testing

- All 14 existing tests pass (cargo test)
- Manual testing on Upgrades tab with Space, a, U keybindings
