### PR TITLE
fix: increase keyhints section length in status bar to avoid hint text clipping

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -503,7 +503,7 @@ fn draw_status_bar(f: &mut Frame, app: &App, area: Rect) {
         .constraints([
             Constraint::Length(14), // filter badge
             Constraint::Min(1),    // status message
-            Constraint::Length(50), // keyhints
+            Constraint::Length(56), // keyhints
         ])
         .split(area);
 


### PR DESCRIPTION
**Problem:** The hints text in the status bar is cut off at the word 'help'

Before fix
<img width="403" height="90" alt="before" src="https://github.com/user-attachments/assets/bf2a52fe-5971-473a-aadc-926f30e6c505" />

**Cause:** The section constraint length is smaller than the actual length of the keyhint string

**Fix:** Increase the constraint length value to match the actual string length

After fix
<img width="386" height="92" alt="after" src="https://github.com/user-attachments/assets/e9446291-1d86-4257-b89e-4528e9d8a252" />



