### PR TITLE
fix: truncated name prevents details loading

### DIFF
--- a/src/cli_backend.rs
+++ b/src/cli_backend.rs
@@ -654,11 +654,13 @@ Name                                  Id                                    Vers
 ---------------------------------------------------------------------------------------
 Bluesky                               MSIX\\bsky.app-C52C8C38_1.0.0.0_neutr\u{2026} 1.0.0.0
 Slack                                 SlackTechnologies.Slack               4.48.92.0
+Microsoft Windows Desktop Runtime 10.\u{2026} Microsoft.DotNet.DesktopRuntime.10   10.0.4
 ";
         let packages = backend.parse_packages_from_table(output);
-        assert_eq!(packages.len(), 2);
+        assert_eq!(packages.len(), 3);
         assert!(packages[0].is_truncated(), "truncated MSIX ID should be detected");
         assert!(!packages[1].is_truncated(), "normal ID should not be truncated");
+        assert!(!packages[2].is_truncated(), "normal ID with truncated name should not be truncated");
     }
 
     #[test]

--- a/src/models.rs
+++ b/src/models.rs
@@ -60,7 +60,7 @@ impl Package {
     /// Returns true if the package ID was truncated by winget (ends with '…').
     /// Truncated IDs cannot be used with `winget show --exact`.
     pub fn is_truncated(&self) -> bool {
-        self.id.ends_with('…') || self.name.ends_with('…')
+        self.id.ends_with('…')
     }
 }
 


### PR DESCRIPTION
This PR changes package is_truncated() call to consider only package id truncation. If only name is truncated, it doesn't prevent loading details with `winget show --id <id> --exact`.

parse_table_with_truncated_ids test extended to cover this case.