### PR TITLE
security: fix command injection in open_url via malicious homepage URL

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -253,8 +253,12 @@ fn handle_normal_mode(
             if let Some(detail) = &app.detail {
                 if !detail.homepage.is_empty() {
                     let url = detail.homepage.clone();
-                    open_url(&url);
-                    app.set_status(format!("Opening {}…", url));
+                    if url.starts_with("http://") || url.starts_with("https://") {
+                        open_url(&url);
+                        app.set_status(format!("Opening {}…", url));
+                    } else {
+                        app.set_status("Blocked: URL must start with http:// or https://");
+                    }
                 }
             }
         }
@@ -405,12 +409,15 @@ fn in_rect(col: u16, row: u16, rect: ratatui::layout::Rect) -> bool {
 }
 
 /// Open a URL in the system default browser.
+/// Only accepts http:// and https:// URLs to prevent command injection.
 fn open_url(url: &str) {
+    if !url.starts_with("http://") && !url.starts_with("https://") {
+        return;
+    }
     #[cfg(target_os = "windows")]
     {
-        let _ = std::process::Command::new("cmd")
-            .args(["/c", "start", "", url])
-            .spawn();
+        // Use explorer.exe instead of cmd /c start to avoid shell metacharacter injection
+        let _ = std::process::Command::new("explorer").arg(url).spawn();
     }
     #[cfg(target_os = "macos")]
     {


### PR DESCRIPTION
## Security Fix: Command injection via open_url

**Severity:** High (all 3 models agreed: Codex, Gemini, Opus)

### The Vulnerability
`open_url` used `cmd /c start "" <url>` to open package homepages. On Windows, `cmd.exe` interprets `&`, `|`, `>` as command separators. A malicious package homepage like `https://x.com&powershell -c malicious` executes arbitrary code when the user presses `o`.

### The Fix
- Replace `cmd /c start` with `explorer.exe` on Windows (no shell metacharacter interpretation)
- Validate URLs must start with `http://` or `https://` before opening
- Show status message if URL validation fails
