### PR TITLE
Simplify WinGet submission action

### DIFF
--- a/.github/workflows/winget-submit.yml
+++ b/.github/workflows/winget-submit.yml
@@ -1,173 +1,38 @@
-name: Winget Submit
+name: Submit release to the WinGet community repository
 
 on:
   release:
     types: [published]
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: Release tag to submit, for example v0.11.0
-        required: true
 
 permissions:
   contents: read
 
 jobs:
-  submit:
-    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'v')
+  publish-winget:
+    name: Submit to WinGet repository
+
+    # winget-create is only supported on Windows
     runs-on: windows-latest
 
+    # winget-create will read the following environment variable to access the GitHub token needed for submitting a PR
+    # See https://aka.ms/winget-create-token
     env:
-      PACKAGE_ID: Hanselman.WingetTUI
-      COMMAND_ALIAS: winget-tui
       WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_CREATE_GITHUB_TOKEN }}
-      GH_TOKEN: ${{ github.token }}
 
+    # Only submit stable releases
+    if: ${{ !github.event.release.prerelease }}
     steps:
-      - uses: actions/checkout@v7
-
-      - name: Resolve release
-        shell: pwsh
+      - name: Submit package using wingetcreate
         run: |
-          $tag = if ("${{ github.event_name }}" -eq "release") {
-            "${{ github.event.release.tag_name }}"
-          } else {
-            "${{ inputs.tag }}"
-          }
+          # Get installer info from release event
+          $assets = '${{ toJSON(github.event.release.assets) }}' | ConvertFrom-Json
+          $x64InstallerUrl = $assets | Where-Object -Property name -like '*tui-x64.exe' | Select-Object -ExpandProperty browser_download_url
+          $arm64InstallerUrl = $assets | Where-Object -Property name -like '*tui-arm64.exe' | Select-Object -ExpandProperty browser_download_url
+          $packageVersion = (${{ toJSON(github.event.release.tag_name) }}).Trim('v')
 
-          if ([string]::IsNullOrWhiteSpace($tag)) {
-            throw "A release tag is required."
-          }
-
-          $version = $tag.TrimStart("v")
-          "TAG=$tag" >> $env:GITHUB_ENV
-          "VERSION=$version" >> $env:GITHUB_ENV
-          "RELEASE_URL=https://github.com/${{ github.repository }}/releases/tag/$tag" >> $env:GITHUB_ENV
-
-      - name: Download release assets
-        shell: pwsh
-        run: |
-          $baseUrl = "https://github.com/${{ github.repository }}/releases/download/$env:TAG"
-          $assets = @(
-            @{ Name = "$env:COMMAND_ALIAS-$env:VERSION-x64.zip"; EnvName = "X64_SHA256" },
-            @{ Name = "$env:COMMAND_ALIAS-$env:VERSION-arm64.zip"; EnvName = "ARM64_SHA256" }
-          )
-
-          New-Item -ItemType Directory -Path ".winget-assets" -Force | Out-Null
-          foreach ($asset in $assets) {
-            $url = "$baseUrl/$($asset.Name)"
-            $path = Join-Path ".winget-assets" $asset.Name
-            Invoke-WebRequest -Uri $url -OutFile $path
-            $hash = (Get-FileHash -Algorithm SHA256 -Path $path).Hash
-            "$($asset.EnvName)=$hash" >> $env:GITHUB_ENV
-          }
-
-      - name: Create manifest
-        shell: pwsh
-        run: |
-          $manifestRoot = Join-Path "winget-manifest" "manifests/h/Hanselman/WingetTUI/$env:VERSION"
-          New-Item -ItemType Directory -Path $manifestRoot -Force | Out-Null
-
-          $release = gh release view $env:TAG --repo $env:GITHUB_REPOSITORY --json publishedAt | ConvertFrom-Json
-          $releaseDate = ([DateTime]$release.publishedAt).ToUniversalTime().ToString("yyyy-MM-dd")
-          $baseUrl = "https://github.com/$env:GITHUB_REPOSITORY/releases/download/$env:TAG"
-          $x64Url = "$baseUrl/$env:COMMAND_ALIAS-$env:VERSION-x64.zip"
-          $arm64Url = "$baseUrl/$env:COMMAND_ALIAS-$env:VERSION-arm64.zip"
-
-          @"
-          # yaml-language-server: `$schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
-
-          PackageIdentifier: $env:PACKAGE_ID
-          PackageVersion: $env:VERSION
-          DefaultLocale: en-US
-          ManifestType: version
-          ManifestVersion: 1.10.0
-          "@ -replace "^[ \t]{10}", "" | Set-Content -Path (Join-Path $manifestRoot "$env:PACKAGE_ID.yaml") -Encoding utf8NoBOM
-
-          @"
-          # yaml-language-server: `$schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
-
-          PackageIdentifier: $env:PACKAGE_ID
-          PackageVersion: $env:VERSION
-          PackageLocale: en-US
-          Publisher: Scott Hanselman
-          PublisherUrl: https://www.hanselman.com/
-          PublisherSupportUrl: https://github.com/$env:GITHUB_REPOSITORY/issues
-          Author: Scott Hanselman
-          PackageName: winget-tui
-          PackageUrl: https://github.com/$env:GITHUB_REPOSITORY
-          License: MIT
-          ShortDescription: Terminal UI for Windows Package Manager (winget).
-          Description: A keyboard-first terminal interface for searching, installing, uninstalling, and upgrading Windows packages with winget.
-          Moniker: winget-tui
-          Tags:
-          - winget
-          - terminal
-          - tui
-          - package-manager
-          - windows
-          ReleaseNotesUrl: $env:RELEASE_URL
-          ManifestType: defaultLocale
-          ManifestVersion: 1.10.0
-          "@ -replace "^[ \t]{10}", "" | Set-Content -Path (Join-Path $manifestRoot "$env:PACKAGE_ID.locale.en-US.yaml") -Encoding utf8NoBOM
-
-          @"
-          # yaml-language-server: `$schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
-
-          PackageIdentifier: $env:PACKAGE_ID
-          PackageVersion: $env:VERSION
-          InstallerType: zip
-          NestedInstallerType: portable
-          UpgradeBehavior: uninstallPrevious
-          Commands:
-          - winget-tui
-          Installers:
-          - Architecture: x64
-            NestedInstallerFiles:
-            - RelativeFilePath: winget-tui-$env:VERSION-x64\winget-tui.exe
-              PortableCommandAlias: winget-tui
-            InstallerUrl: $x64Url
-            InstallerSha256: $env:X64_SHA256
-          - Architecture: arm64
-            NestedInstallerFiles:
-            - RelativeFilePath: winget-tui-$env:VERSION-arm64\winget-tui.exe
-              PortableCommandAlias: winget-tui
-            InstallerUrl: $arm64Url
-            InstallerSha256: $env:ARM64_SHA256
-          ManifestType: installer
-          ManifestVersion: 1.10.0
-          ReleaseDate: $releaseDate
-          "@ -replace "^[ \t]{10}", "" | Set-Content -Path (Join-Path $manifestRoot "$env:PACKAGE_ID.installer.yaml") -Encoding utf8NoBOM
-
-          "MANIFEST_ROOT=$manifestRoot" >> $env:GITHUB_ENV
-
-      - name: Validate manifest
-        shell: pwsh
-        run: |
-          if (Get-Command winget -ErrorAction SilentlyContinue) {
-            winget validate --manifest $env:MANIFEST_ROOT
-          } else {
-            Write-Warning "winget is not available on this runner; skipping local manifest validation."
-          }
-
-      - name: Setup .NET for WingetCreate
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: 6.0.x
-
-      - name: Download WingetCreate
-        shell: pwsh
-        run: Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-
-      - name: Submit manifest
-        shell: pwsh
-        run: |
-          if ([string]::IsNullOrWhiteSpace($env:WINGET_CREATE_GITHUB_TOKEN)) {
-            throw "Set the WINGET_CREATE_GITHUB_TOKEN repository secret before submitting Winget manifests."
-          }
-
-          .\wingetcreate.exe submit `
-            --prtitle "New version: $env:PACKAGE_ID version $env:VERSION" `
-            --token $env:WINGET_CREATE_GITHUB_TOKEN `
-            --no-open `
-            $env:MANIFEST_ROOT
+          # Update package using wingetcreate
+          curl.exe -JLO https://aka.ms/wingetcreate/latest
+          .\wingetcreate.exe update Hanselman.WingetTUI `
+            --version $packageVersion `
+            --urls $x64InstallerUrl $arm64InstallerUrl `
+            --submit


### PR DESCRIPTION
### Description

Refactors the workflow to be in line with our other repos:

- [Copilot CLI](https://github.com/github/copilot-cli/blob/v0.0.368-2/.github/workflows/winget.yml)
- [Edit](https://github.com/microsoft/edit/blob/main/.github/workflows/winget.yml)
- [Oh-My-Posh](https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/.github/workflows/release.yml#L139)
- [PowerToys](https://github.com/microsoft/PowerToys/blob/main/.github/workflows/package-submissions.yml)
- [Terminal](https://github.com/microsoft/terminal/blob/main/.github/workflows/winget.yml)
- [WinGet Studio](https://github.com/microsoft/winget-studio/blob/main/.github/workflows/winget.yml)


### Testing

For testing with wingetcreate just omit the `--submit` flag to avoid sending an actual PR.

```pwsh
wingetcreate.exe update Hanselman.WingetTUI `
--version 0.2.0 `
--urls https://github.com/shanselman/winget-tui/releases/download/v0.13.0/winget-tui-x64.exe https://github.com/shanselman/winget-tui/releases/download/v0.13.0/winget-tui-arm64.exe
```