### PR TITLE
Feature: Add accessible theme support

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,12 @@ default_view = "upgrades"          # installed | search | upgrades
 default_source = "winget"          # all | winget | msstore
 default_sort = "name"              # name | name_desc | id | id_desc | version | version_desc | none
 default_pin_filter = "hide_pinned" # all | pinned | hide_pinned
-theme = "retro"                    # original | retro | nord
+theme = "retro"                    # original | retro | nord | terminal
 ```
+
+The `terminal` theme inherits the terminal profile's foreground and background
+colors, preserving transparency, custom color schemes, and system contrast
+settings. `system` is accepted as an alias.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A terminal user interface for [Windows Package Manager (winget)](https://github.
 - **Package Details** — View publisher, description, license, homepage, and release notes
 - **Graceful Local Package Info** — Non-winget installs still show a useful explanation when rich manifest metadata is unavailable
 - **Scrollable Details Pane** — Read long descriptions without losing your place in the package list
-- **Configurable Startup Defaults** — Set your default view and source in `config.toml`
+- **Configurable Themes and Startup Defaults** — Select an accessible color preset and default view in `config.toml`
 - **Keyboard-Driven** — Vim-style navigation, no mouse needed
 - **Non-Blocking** — Install/uninstall/upgrade run in the background
 - **Single Binary** — No runtime dependencies beyond winget itself
@@ -166,6 +166,7 @@ default_view = "upgrades"          # installed | search | upgrades
 default_source = "winget"          # all | winget | msstore
 default_sort = "name"              # name | name_desc | id | id_desc | version | version_desc | none
 default_pin_filter = "hide_pinned" # all | pinned | hide_pinned
+theme = "retro"                    # original | retro | nord
 ```
 
 ## Architecture

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,6 +10,7 @@ use crate::models::{
     OpResult, Operation, Package, PackageDetail, PackagePin, PinFilter, SortDir, SortField,
     SourceFilter,
 };
+use crate::theme::Theme;
 
 /// Stores UI layout regions for mouse hit-testing
 #[derive(Debug, Default, Clone)]
@@ -108,6 +109,7 @@ pub struct ConfirmDialog {
 }
 
 pub struct App {
+    pub theme: Theme,
     pub mode: AppMode,
     pub input_mode: InputMode,
     pub focus: FocusZone,
@@ -215,6 +217,7 @@ impl App {
     pub fn new(backend: Arc<dyn WingetBackend>, cfg: Config) -> Self {
         let (message_tx, message_rx) = tokio::sync::mpsc::unbounded_channel();
         Self {
+            theme: Theme::from_name(cfg.theme),
             mode: cfg.default_view,
             input_mode: InputMode::Normal,
             focus: FocusZone::PackageList,

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,7 +10,7 @@
 /// default_source     = "all"         # "all" | "winget" | "msstore"
 /// default_sort       = "name"        # name | name_desc | id | id_desc | version | version_desc | none
 /// default_pin_filter = "all"         # "all" | "pinned" | "hide_pinned"
-/// theme              = "original"    # "original" | "retro" | "nord"
+/// theme              = "original"    # "original" | "retro" | "nord" | "terminal"
 /// ```
 use crate::app::AppMode;
 use crate::models::{PinFilter, SortDir, SortField, SourceFilter};
@@ -169,6 +169,14 @@ mod tests {
         );
         assert_eq!(Config::parse(r#"theme = "ReTrO""#).theme, ThemeName::Retro);
         assert_eq!(Config::parse(r#"theme = "NORD""#).theme, ThemeName::Nord);
+        assert_eq!(
+            Config::parse(r#"theme = "terminal""#).theme,
+            ThemeName::Terminal
+        );
+        assert_eq!(
+            Config::parse(r#"theme = "system""#).theme,
+            ThemeName::Terminal
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,9 +13,11 @@
 /// ```
 use crate::app::AppMode;
 use crate::models::{PinFilter, SortDir, SortField, SourceFilter};
+use crate::theme::ThemeName;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Config {
+    pub theme: ThemeName,
     pub default_view: AppMode,
     pub default_source: SourceFilter,
     pub default_sort_field: SortField,
@@ -26,6 +28,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
+            theme: ThemeName::Original,
             default_view: AppMode::Installed,
             default_source: SourceFilter::All,
             default_sort_field: SortField::None,
@@ -96,6 +99,9 @@ impl Config {
                 raw.split_once('#').map(|(v, _)| v.trim()).unwrap_or(raw)
             };
             match key {
+                "theme" => {
+                    cfg.theme = ThemeName::parse(value);
+                }
                 "default_view" => {
                     cfg.default_view = match value {
                         "search" => AppMode::Search,
@@ -152,6 +158,32 @@ mod tests {
     fn parse_empty_string_returns_defaults() {
         let cfg = Config::parse("");
         assert_eq!(cfg, Config::default());
+    }
+
+    #[test]
+    fn parse_theme_names_case_insensitively() {
+        assert_eq!(
+            Config::parse(r#"theme = "original""#).theme,
+            ThemeName::Original
+        );
+        assert_eq!(Config::parse(r#"theme = "ReTrO""#).theme, ThemeName::Retro);
+        assert_eq!(Config::parse(r#"theme = "NORD""#).theme, ThemeName::Nord);
+    }
+
+    #[test]
+    fn parse_unknown_theme_falls_back_to_original() {
+        assert_eq!(
+            Config::parse(r#"theme = "unknown""#).theme,
+            ThemeName::Original
+        );
+    }
+
+    #[test]
+    fn parse_inline_comment_on_theme() {
+        assert_eq!(
+            Config::parse(r#"theme = "retro" # original | retro | nord"#).theme,
+            ThemeName::Retro
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,7 @@
 /// default_source     = "all"         # "all" | "winget" | "msstore"
 /// default_sort       = "name"        # name | name_desc | id | id_desc | version | version_desc | none
 /// default_pin_filter = "all"         # "all" | "pinned" | "hide_pinned"
+/// theme              = "original"    # "original" | "retro" | "nord"
 /// ```
 use crate::app::AppMode;
 use crate::models::{PinFilter, SortDir, SortField, SourceFilter};

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -75,7 +75,7 @@ impl Theme {
             background: Color::Rgb(46, 52, 64),
             surface: Color::Rgb(59, 66, 82),
             text_primary: Color::Rgb(236, 239, 244),
-            text_secondary: Color::Rgb(216, 222, 233),
+            text_secondary: Color::Rgb(168, 180, 198),
             accent: Color::Rgb(136, 192, 208),
             accent_dim: Color::Rgb(115, 128, 151),
             success: Color::Rgb(163, 190, 140),
@@ -93,11 +93,35 @@ impl Theme {
         }
     }
 
+    pub const fn terminal() -> Self {
+        Self {
+            background: Color::Reset,
+            surface: Color::Reset,
+            text_primary: Color::Reset,
+            text_secondary: Color::Reset,
+            accent: Color::Cyan,
+            accent_dim: Color::DarkGray,
+            success: Color::Green,
+            error: Color::LightRed,
+            info: Color::LightCyan,
+            selection: Color::Magenta,
+            install: Color::Yellow,
+            danger: Color::Red,
+            on_accent: Color::Black,
+            on_success: Color::Black,
+            on_info: Color::Black,
+            on_selection: Color::White,
+            on_install: Color::Black,
+            on_danger: Color::White,
+        }
+    }
+
     pub const fn from_name(name: ThemeName) -> Self {
         match name {
             ThemeName::Original => Self::original(),
             ThemeName::Retro => Self::retro(),
             ThemeName::Nord => Self::nord(),
+            ThemeName::Terminal => Self::terminal(),
         }
     }
 }
@@ -113,6 +137,7 @@ pub enum ThemeName {
     Original,
     Retro,
     Nord,
+    Terminal,
 }
 
 impl ThemeName {
@@ -121,6 +146,8 @@ impl ThemeName {
             Self::Retro
         } else if value.eq_ignore_ascii_case("nord") {
             Self::Nord
+        } else if value.eq_ignore_ascii_case("terminal") || value.eq_ignore_ascii_case("system") {
+            Self::Terminal
         } else {
             Self::Original
         }
@@ -136,13 +163,23 @@ pub fn surface(theme: &Theme) -> Style {
 }
 
 pub fn secondary(theme: &Theme) -> Style {
-    Style::default()
+    let style = Style::default()
         .fg(theme.text_secondary)
-        .bg(theme.background)
+        .bg(theme.background);
+    if theme.text_secondary == Color::Reset {
+        style.add_modifier(Modifier::DIM)
+    } else {
+        style
+    }
 }
 
 pub fn surface_secondary(theme: &Theme) -> Style {
-    Style::default().fg(theme.text_secondary).bg(theme.surface)
+    let style = Style::default().fg(theme.text_secondary).bg(theme.surface);
+    if theme.text_secondary == Color::Reset {
+        style.add_modifier(Modifier::DIM)
+    } else {
+        style
+    }
 }
 
 pub fn success_text(theme: &Theme) -> Style {
@@ -321,15 +358,15 @@ mod tests {
     const MIN_TEXT_CONTRAST: f64 = 4.5;
     const MIN_NON_TEXT_CONTRAST: f64 = 3.0;
 
-    fn rgb(color: Color) -> (u8, u8, u8) {
+    fn rgb(color: Color) -> Option<(u8, u8, u8)> {
         match color {
-            Color::Rgb(red, green, blue) => (red, green, blue),
-            other => panic!("theme colors must be RGB, got {other:?}"),
+            Color::Rgb(red, green, blue) => Some((red, green, blue)),
+            _ => None,
         }
     }
 
-    fn relative_luminance(color: Color) -> f64 {
-        let (red, green, blue) = rgb(color);
+    fn relative_luminance(color: Color) -> Option<f64> {
+        let (red, green, blue) = rgb(color)?;
         let channel = |value: u8| {
             let value = f64::from(value) / 255.0;
             if value <= 0.04045 {
@@ -338,18 +375,18 @@ mod tests {
                 ((value + 0.055) / 1.055).powf(2.4)
             }
         };
-        0.2126 * channel(red) + 0.7152 * channel(green) + 0.0722 * channel(blue)
+        Some(0.2126 * channel(red) + 0.7152 * channel(green) + 0.0722 * channel(blue))
     }
 
-    fn contrast(foreground: Color, background: Color) -> f64 {
-        let foreground = relative_luminance(foreground);
-        let background = relative_luminance(background);
+    fn contrast(foreground: Color, background: Color) -> Option<f64> {
+        let foreground = relative_luminance(foreground)?;
+        let background = relative_luminance(background)?;
         let (lighter, darker) = if foreground > background {
             (foreground, background)
         } else {
             (background, foreground)
         };
-        (lighter + 0.05) / (darker + 0.05)
+        Some((lighter + 0.05) / (darker + 0.05))
     }
 
     fn assert_contrast(
@@ -359,7 +396,9 @@ mod tests {
         background: Color,
         minimum: f64,
     ) {
-        let ratio = contrast(foreground, background);
+        let Some(ratio) = contrast(foreground, background) else {
+            return;
+        };
         assert!(
             ratio >= minimum,
             "{theme_name} {pair_name} contrast {ratio:.2}:1 is below {minimum:.1}:1"
@@ -371,6 +410,8 @@ mod tests {
         assert_eq!(ThemeName::parse("ORIGINAL"), ThemeName::Original);
         assert_eq!(ThemeName::parse("ReTrO"), ThemeName::Retro);
         assert_eq!(ThemeName::parse("NORD"), ThemeName::Nord);
+        assert_eq!(ThemeName::parse("terminal"), ThemeName::Terminal);
+        assert_eq!(ThemeName::parse("SYSTEM"), ThemeName::Terminal);
         assert_eq!(ThemeName::parse("unknown"), ThemeName::Original);
     }
 
@@ -416,7 +457,28 @@ mod tests {
             ] {
                 assert_contrast(name, pair, foreground, background, MIN_NON_TEXT_CONTRAST);
             }
+
+            assert_contrast(
+                name,
+                "primary/secondary role separation",
+                theme.text_primary,
+                theme.text_secondary,
+                1.5,
+            );
         }
+    }
+
+    #[test]
+    fn terminal_theme_inherits_terminal_foreground_and_background() {
+        let theme = Theme::terminal();
+        assert_eq!(theme.background, Color::Reset);
+        assert_eq!(theme.surface, Color::Reset);
+        assert_eq!(theme.text_primary, Color::Reset);
+        assert_eq!(theme.text_secondary, Color::Reset);
+        assert!(secondary(&theme).add_modifier.contains(Modifier::DIM));
+        assert!(surface_secondary(&theme)
+            .add_modifier
+            .contains(Modifier::DIM));
     }
 
     #[test]

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,217 +1,282 @@
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 
-// ── Winget-inspired color palette ───────────────────────────────────────────
-
-/// Primary accent
-pub const ACCENT: Color = Color::Rgb(238, 201, 141); // #EEC98D
-
-/// Dimmed accent — for focused borders
-pub const ACCENT_DIM: Color = Color::Rgb(137, 130, 112); // #898270
-
-/// Primary text color
-pub const TEXT_PRIMARY: Color = Color::Rgb(232, 220, 183); // #E8DCB7
-
-/// Secondary/dimmed text
-pub const TEXT_SECONDARY: Color = Color::Rgb(158, 158, 158); // #9E9E9E
-
-/// Text rendered on top of accent backgrounds
-pub const TEXT_ON_ACCENT: Color = Color::Rgb(30, 30, 30); // #1E1E1E
-
-/// Panel/surface background
-pub const SURFACE: Color = Color::Rgb(45, 45, 45); // #2D2D2D
-
-/// App background
-#[allow(dead_code)]
-pub const BG: Color = Color::Rgb(30, 30, 30); // #1E1E1E
-
-/// Success (install, available version, updates)
-pub const SUCCESS: Color = Color::Rgb(86, 185, 127); // #56B97F
-
-/// Danger (uninstall, errors)
-pub const DANGER: Color = Color::Rgb(231, 72, 86); // #E74856
-
-/// Info (links, IDs)
-pub const INFO: Color = Color::Rgb(97, 175, 239); // #61AFEF
-
-/// Selection highlight (multi-select markers in upgrades)
-pub const SELECTION: Color = Color::Rgb(198, 120, 221); // #C678DD
-
-// ── Style helpers ───────────────────────────────────────────────────────────
-
-/// Style for a focused panel border
-pub fn border_focused() -> Style {
-    Style::default().fg(ACCENT)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Theme {
+    pub background: Color,
+    pub surface: Color,
+    pub text_primary: Color,
+    pub text_secondary: Color,
+    pub accent: Color,
+    pub accent_dim: Color,
+    pub success: Color,
+    pub error: Color,
+    pub info: Color,
+    pub selection: Color,
+    pub install: Color,
+    pub danger: Color,
+    pub on_accent: Color,
+    pub on_success: Color,
+    pub on_info: Color,
+    pub on_selection: Color,
+    pub on_install: Color,
+    pub on_danger: Color,
 }
 
-/// Style for an unfocused panel border
-pub fn border_unfocused() -> Style {
-    Style::default().fg(ACCENT_DIM)
+impl Theme {
+    pub const fn original() -> Self {
+        Self {
+            background: Color::Rgb(30, 30, 30),
+            surface: Color::Rgb(45, 45, 45),
+            text_primary: Color::Rgb(232, 220, 183),
+            text_secondary: Color::Rgb(158, 158, 158),
+            accent: Color::Rgb(238, 201, 141),
+            accent_dim: Color::Rgb(137, 130, 112),
+            success: Color::Rgb(86, 185, 127),
+            error: Color::Rgb(249, 99, 113),
+            info: Color::Rgb(97, 175, 239),
+            selection: Color::Rgb(198, 120, 221),
+            install: Color::Rgb(189, 63, 57),
+            danger: Color::Rgb(249, 99, 113),
+            on_accent: Color::Rgb(30, 30, 30),
+            on_success: Color::Rgb(30, 30, 30),
+            on_info: Color::Rgb(30, 30, 30),
+            on_selection: Color::Rgb(30, 30, 30),
+            on_install: Color::Rgb(240, 240, 240),
+            on_danger: Color::Rgb(30, 30, 30),
+        }
+    }
+
+    pub const fn retro() -> Self {
+        Self {
+            background: Color::Rgb(5, 18, 8),
+            surface: Color::Rgb(10, 30, 15),
+            text_primary: Color::Rgb(144, 255, 144),
+            text_secondary: Color::Rgb(82, 180, 92),
+            accent: Color::Rgb(102, 255, 102),
+            accent_dim: Color::Rgb(38, 112, 48),
+            success: Color::Rgb(128, 255, 128),
+            error: Color::Rgb(255, 108, 108),
+            info: Color::Rgb(102, 204, 170),
+            selection: Color::Rgb(50, 145, 65),
+            install: Color::Rgb(82, 180, 92),
+            danger: Color::Rgb(255, 108, 108),
+            on_accent: Color::Rgb(5, 18, 8),
+            on_success: Color::Rgb(5, 18, 8),
+            on_info: Color::Rgb(5, 18, 8),
+            on_selection: Color::Rgb(5, 18, 8),
+            on_install: Color::Rgb(5, 18, 8),
+            on_danger: Color::Rgb(5, 18, 8),
+        }
+    }
+
+    pub const fn nord() -> Self {
+        Self {
+            background: Color::Rgb(46, 52, 64),
+            surface: Color::Rgb(59, 66, 82),
+            text_primary: Color::Rgb(236, 239, 244),
+            text_secondary: Color::Rgb(216, 222, 233),
+            accent: Color::Rgb(136, 192, 208),
+            accent_dim: Color::Rgb(115, 128, 151),
+            success: Color::Rgb(163, 190, 140),
+            error: Color::Rgb(238, 150, 157),
+            info: Color::Rgb(150, 181, 211),
+            selection: Color::Rgb(184, 147, 177),
+            install: Color::Rgb(235, 203, 139),
+            danger: Color::Rgb(238, 150, 157),
+            on_accent: Color::Rgb(46, 52, 64),
+            on_success: Color::Rgb(46, 52, 64),
+            on_info: Color::Rgb(46, 52, 64),
+            on_selection: Color::Rgb(46, 52, 64),
+            on_install: Color::Rgb(46, 52, 64),
+            on_danger: Color::Rgb(46, 52, 64),
+        }
+    }
+
+    pub const fn from_name(name: ThemeName) -> Self {
+        match name {
+            ThemeName::Original => Self::original(),
+            ThemeName::Retro => Self::retro(),
+            ThemeName::Nord => Self::nord(),
+        }
+    }
 }
 
-/// Style for the selected row in the package list
-pub fn selected_row() -> Style {
+impl Default for Theme {
+    fn default() -> Self {
+        Self::original()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ThemeName {
+    Original,
+    Retro,
+    Nord,
+}
+
+impl ThemeName {
+    pub fn parse(value: &str) -> Self {
+        if value.eq_ignore_ascii_case("retro") {
+            Self::Retro
+        } else if value.eq_ignore_ascii_case("nord") {
+            Self::Nord
+        } else {
+            Self::Original
+        }
+    }
+}
+
+pub fn root(theme: &Theme) -> Style {
+    Style::default().fg(theme.text_primary).bg(theme.background)
+}
+
+pub fn surface(theme: &Theme) -> Style {
+    Style::default().fg(theme.text_primary).bg(theme.surface)
+}
+
+pub fn secondary(theme: &Theme) -> Style {
     Style::default()
-        .fg(TEXT_ON_ACCENT)
-        .bg(ACCENT)
+        .fg(theme.text_secondary)
+        .bg(theme.background)
+}
+
+pub fn surface_secondary(theme: &Theme) -> Style {
+    Style::default().fg(theme.text_secondary).bg(theme.surface)
+}
+
+pub fn success_text(theme: &Theme) -> Style {
+    Style::default().fg(theme.success).bg(theme.background)
+}
+
+pub fn info_text(theme: &Theme) -> Style {
+    Style::default().fg(theme.info).bg(theme.background)
+}
+
+pub fn border_focused(theme: &Theme) -> Style {
+    Style::default().fg(theme.accent).bg(theme.background)
+}
+
+pub fn border_unfocused(theme: &Theme) -> Style {
+    Style::default().fg(theme.accent_dim).bg(theme.background)
+}
+
+pub fn selected_row(theme: &Theme) -> Style {
+    Style::default()
+        .fg(theme.on_accent)
+        .bg(theme.accent)
         .add_modifier(Modifier::BOLD)
 }
 
-/// Style for a multi-select marked row (not currently highlighted)
-pub fn marked_row() -> Style {
-    Style::default().fg(SUCCESS).add_modifier(Modifier::BOLD)
-}
-
-/// Style for table column headers
-pub fn table_header() -> Style {
-    Style::default().fg(ACCENT).add_modifier(Modifier::BOLD)
-}
-
-/// Style for panel/block titles
-pub fn title() -> Style {
+pub fn marked_row(theme: &Theme) -> Style {
     Style::default()
-        .fg(TEXT_PRIMARY)
+        .fg(theme.success)
+        .bg(theme.background)
         .add_modifier(Modifier::BOLD)
 }
 
-/// Style for detail panel labels (Name, ID, Version, etc.)
-pub fn detail_label() -> Style {
-    Style::default().fg(ACCENT).add_modifier(Modifier::BOLD)
-}
-
-/// Active navbar item
-pub fn navbar_active() -> Style {
+pub fn table_header(theme: &Theme) -> Style {
     Style::default()
-        .fg(TEXT_ON_ACCENT)
-        .bg(ACCENT)
+        .fg(theme.accent)
+        .bg(theme.background)
         .add_modifier(Modifier::BOLD)
 }
 
-/// Inactive navbar item
-pub fn navbar_inactive() -> Style {
-    Style::default().fg(TEXT_SECONDARY)
-}
-
-/// Key hint style (status bar)
-#[allow(dead_code)]
-pub fn keyhint() -> Style {
-    Style::default().fg(TEXT_SECONDARY).bg(SURFACE)
-}
-
-/// Status bar style for normal messages
-pub fn status_normal() -> Style {
-    Style::default().fg(TEXT_PRIMARY).bg(SURFACE)
-}
-
-/// Status bar style when loading
-pub fn status_loading() -> Style {
-    Style::default().fg(ACCENT).bg(SURFACE)
-}
-
-/// Status bar style on error
-pub fn status_error() -> Style {
-    Style::default().fg(DANGER).bg(SURFACE)
-}
-
-/// Action button: install
-pub fn action_install() -> Style {
+pub fn title(theme: &Theme) -> Style {
     Style::default()
-        .fg(TEXT_PRIMARY)
-        .bg(Color::Rgb(189, 63, 57)) // #BD3F39
+        .fg(theme.text_primary)
+        .bg(theme.background)
         .add_modifier(Modifier::BOLD)
 }
 
-/// Action button: confirm (yes)
-pub fn action_confirm() -> Style {
+pub fn detail_label(theme: &Theme) -> Style {
     Style::default()
-        .fg(TEXT_ON_ACCENT)
-        .bg(SUCCESS)
+        .fg(theme.accent)
+        .bg(theme.background)
         .add_modifier(Modifier::BOLD)
 }
 
-/// Action button: upgrade
-#[allow(dead_code)]
-pub fn action_upgrade() -> Style {
+pub fn navbar_active(theme: &Theme) -> Style {
     Style::default()
-        .fg(TEXT_ON_ACCENT)
-        .bg(ACCENT)
+        .fg(theme.on_accent)
+        .bg(theme.accent)
         .add_modifier(Modifier::BOLD)
 }
 
-/// Action button key badge (uniform style for all key indicators)
-pub fn action_key() -> Style {
+pub fn navbar_inactive(theme: &Theme) -> Style {
+    secondary(theme)
+}
+
+pub fn status_normal(theme: &Theme) -> Style {
+    surface(theme)
+}
+
+pub fn status_loading(theme: &Theme) -> Style {
+    Style::default().fg(theme.accent).bg(theme.surface)
+}
+
+pub fn status_error(theme: &Theme) -> Style {
+    Style::default().fg(theme.error).bg(theme.surface)
+}
+
+pub fn action_install(theme: &Theme) -> Style {
     Style::default()
-        .fg(TEXT_ON_ACCENT)
-        .bg(ACCENT)
+        .fg(theme.on_install)
+        .bg(theme.install)
         .add_modifier(Modifier::BOLD)
 }
 
-/// Action button: uninstall / danger
-pub fn action_danger() -> Style {
+pub fn action_confirm(theme: &Theme) -> Style {
     Style::default()
-        .fg(TEXT_PRIMARY)
-        .bg(DANGER)
+        .fg(theme.on_success)
+        .bg(theme.success)
         .add_modifier(Modifier::BOLD)
 }
 
-/// Action button: info (open homepage)
-#[allow(dead_code)]
-pub fn action_info() -> Style {
+pub fn action_key(theme: &Theme) -> Style {
     Style::default()
-        .fg(TEXT_ON_ACCENT)
-        .bg(INFO)
+        .fg(theme.on_accent)
+        .bg(theme.accent)
         .add_modifier(Modifier::BOLD)
 }
 
-/// Action button: selection (space, select all)
-#[allow(dead_code)]
-pub fn action_selection() -> Style {
+pub fn action_danger(theme: &Theme) -> Style {
     Style::default()
-        .fg(TEXT_ON_ACCENT)
-        .bg(SELECTION)
+        .fg(theme.on_danger)
+        .bg(theme.danger)
         .add_modifier(Modifier::BOLD)
 }
 
-/// Help overlay section header
-pub fn help_section() -> Style {
-    Style::default().fg(ACCENT).add_modifier(Modifier::BOLD)
+pub fn source_winget(theme: &Theme) -> Style {
+    Style::default()
+        .fg(theme.on_info)
+        .bg(theme.info)
+        .add_modifier(Modifier::BOLD)
 }
 
-/// Help overlay key binding text
-pub fn help_key() -> Style {
-    Style::default().fg(INFO)
+pub fn source_msstore(theme: &Theme) -> Style {
+    Style::default()
+        .fg(theme.on_selection)
+        .bg(theme.selection)
+        .add_modifier(Modifier::BOLD)
 }
 
-// ── Winget Icon (half-block pixel art) ───────────────────────────────────────
+pub fn help_section(theme: &Theme) -> Style {
+    Style::default()
+        .fg(theme.accent)
+        .bg(theme.surface)
+        .add_modifier(Modifier::BOLD)
+}
 
-// Icon colors from the SVG (kept for potential future use)
-#[allow(dead_code)]
-const ICON_BROWN: Color = Color::Rgb(156, 100, 10); // #9C640A back card
-#[allow(dead_code)]
-const ICON_AMBER: Color = Color::Rgb(188, 130, 42); // #BC822A mid card
-#[allow(dead_code)]
-const ICON_GOLD: Color = Color::Rgb(222, 182, 120); // #DEB678 front card
-#[allow(dead_code)]
-const ICON_ARROW: Color = Color::Rgb(240, 240, 240); // #F0F0F0 arrow
+pub fn help_key(theme: &Theme) -> Style {
+    Style::default().fg(theme.info).bg(theme.surface)
+}
 
-/// Height of the logo in text rows
 pub const LOGO_HEIGHT: u16 = 3;
 
-/// Render "winget" as pixel word art using half-blocks.
-/// 3 text rows tall (6 pixel rows), rendered in the accent color.
-pub fn logo_lines() -> Vec<Line<'static>> {
-    // Letters designed on a 5x6 grid (or narrower), 1px gap between each.
-    //
-    //  w         i     n         g         e         t
-    //  #   #     #     #   #     ###       ###      ###
-    //  #   #     #     ##  #     #         #         #
-    //  # # #     #     # # #     # ##      ##        #
-    //  # # #     #     #  ##     #  #      #         #
-    //  ## ##     #     #   #     ###       ###       #
-    //
+pub fn logo_lines(theme: &Theme) -> Vec<Line<'static>> {
     #[rustfmt::skip]
     const GRID: [[u8; 31]; 6] = [
-      // w . . . .   i   n . . . .   g . . . .   e . . .   t . .
         [1,0,0,0,1, 0,1, 0,1,0,0,1, 0,0,1,1,1, 0,1,1,1, 0,1,1,1, 0,0,0,0,0,0],
         [1,0,0,0,1, 0,1, 0,1,1,0,1, 0,1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,0,0,0],
         [1,0,1,0,1, 0,1, 0,1,0,1,1, 0,1,0,1,1, 0,1,1,0, 0,0,1,0, 0,0,0,0,0,0],
@@ -220,26 +285,160 @@ pub fn logo_lines() -> Vec<Line<'static>> {
         [0,0,0,0,0, 0,0, 0,0,0,0,0, 0,0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,0,0],
     ];
 
-    let color = ACCENT;
     let mut lines = Vec::new();
-
     for text_row in 0..3 {
         let top = &GRID[text_row * 2];
-        let bot = &GRID[text_row * 2 + 1];
+        let bottom = &GRID[text_row * 2 + 1];
         let mut spans = Vec::new();
 
-        for col in 0..31 {
-            let t = top[col] == 1;
-            let b = bot[col] == 1;
-            match (t, b) {
+        for column in 0..31 {
+            match (top[column] == 1, bottom[column] == 1) {
                 (false, false) => spans.push(Span::raw(" ")),
-                (true, true) => spans.push(Span::styled("\u{2588}", Style::default().fg(color))),
-                (true, false) => spans.push(Span::styled("\u{2580}", Style::default().fg(color))),
-                (false, true) => spans.push(Span::styled("\u{2584}", Style::default().fg(color))),
+                (true, true) => spans.push(Span::styled(
+                    "\u{2588}",
+                    Style::default().fg(theme.accent).bg(theme.background),
+                )),
+                (true, false) => spans.push(Span::styled(
+                    "\u{2580}",
+                    Style::default().fg(theme.accent).bg(theme.background),
+                )),
+                (false, true) => spans.push(Span::styled(
+                    "\u{2584}",
+                    Style::default().fg(theme.accent).bg(theme.background),
+                )),
             }
         }
         lines.push(Line::from(spans));
     }
 
     lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MIN_TEXT_CONTRAST: f64 = 4.5;
+    const MIN_NON_TEXT_CONTRAST: f64 = 3.0;
+
+    fn rgb(color: Color) -> (u8, u8, u8) {
+        match color {
+            Color::Rgb(red, green, blue) => (red, green, blue),
+            other => panic!("theme colors must be RGB, got {other:?}"),
+        }
+    }
+
+    fn relative_luminance(color: Color) -> f64 {
+        let (red, green, blue) = rgb(color);
+        let channel = |value: u8| {
+            let value = f64::from(value) / 255.0;
+            if value <= 0.04045 {
+                value / 12.92
+            } else {
+                ((value + 0.055) / 1.055).powf(2.4)
+            }
+        };
+        0.2126 * channel(red) + 0.7152 * channel(green) + 0.0722 * channel(blue)
+    }
+
+    fn contrast(foreground: Color, background: Color) -> f64 {
+        let foreground = relative_luminance(foreground);
+        let background = relative_luminance(background);
+        let (lighter, darker) = if foreground > background {
+            (foreground, background)
+        } else {
+            (background, foreground)
+        };
+        (lighter + 0.05) / (darker + 0.05)
+    }
+
+    fn assert_contrast(
+        theme_name: &str,
+        pair_name: &str,
+        foreground: Color,
+        background: Color,
+        minimum: f64,
+    ) {
+        let ratio = contrast(foreground, background);
+        assert!(
+            ratio >= minimum,
+            "{theme_name} {pair_name} contrast {ratio:.2}:1 is below {minimum:.1}:1"
+        );
+    }
+
+    #[test]
+    fn theme_names_are_case_insensitive() {
+        assert_eq!(ThemeName::parse("ORIGINAL"), ThemeName::Original);
+        assert_eq!(ThemeName::parse("ReTrO"), ThemeName::Retro);
+        assert_eq!(ThemeName::parse("NORD"), ThemeName::Nord);
+        assert_eq!(ThemeName::parse("unknown"), ThemeName::Original);
+    }
+
+    #[test]
+    fn rendered_semantic_pairs_meet_contrast_floors() {
+        for (name, theme) in [
+            ("original", Theme::original()),
+            ("retro", Theme::retro()),
+            ("nord", Theme::nord()),
+        ] {
+            for (pair, foreground, background) in [
+                ("root text", theme.text_primary, theme.background),
+                (
+                    "root secondary text",
+                    theme.text_secondary,
+                    theme.background,
+                ),
+                ("surface text", theme.text_primary, theme.surface),
+                (
+                    "surface secondary text",
+                    theme.text_secondary,
+                    theme.surface,
+                ),
+                ("accent text", theme.accent, theme.background),
+                ("surface accent text", theme.accent, theme.surface),
+                ("success text", theme.success, theme.background),
+                ("error text", theme.error, theme.surface),
+                ("info text", theme.info, theme.background),
+                ("surface info text", theme.info, theme.surface),
+                ("selected row", theme.on_accent, theme.accent),
+                ("confirm action", theme.on_success, theme.success),
+                ("Winget badge", theme.on_info, theme.info),
+                ("MsStore badge", theme.on_selection, theme.selection),
+                ("install action", theme.on_install, theme.install),
+                ("danger action", theme.on_danger, theme.danger),
+            ] {
+                assert_contrast(name, pair, foreground, background, MIN_TEXT_CONTRAST);
+            }
+
+            for (pair, foreground, background) in [
+                ("focused border", theme.accent, theme.background),
+                ("unfocused border", theme.accent_dim, theme.background),
+            ] {
+                assert_contrast(name, pair, foreground, background, MIN_NON_TEXT_CONTRAST);
+            }
+        }
+    }
+
+    #[test]
+    fn original_preserves_existing_colors_except_accessibility_exceptions() {
+        let theme = Theme::original();
+        assert_eq!(theme.background, Color::Rgb(30, 30, 30));
+        assert_eq!(theme.surface, Color::Rgb(45, 45, 45));
+        assert_eq!(theme.text_primary, Color::Rgb(232, 220, 183));
+        assert_eq!(theme.text_secondary, Color::Rgb(158, 158, 158));
+        assert_eq!(theme.accent, Color::Rgb(238, 201, 141));
+        assert_eq!(theme.accent_dim, Color::Rgb(137, 130, 112));
+        assert_eq!(theme.success, Color::Rgb(86, 185, 127));
+        assert_eq!(theme.info, Color::Rgb(97, 175, 239));
+        assert_eq!(theme.selection, Color::Rgb(198, 120, 221));
+        assert_eq!(theme.install, Color::Rgb(189, 63, 57));
+        assert_eq!(theme.error, Color::Rgb(249, 99, 113));
+        assert_eq!(theme.danger, Color::Rgb(249, 99, 113));
+        assert_eq!(theme.on_accent, Color::Rgb(30, 30, 30));
+        assert_eq!(theme.on_success, Color::Rgb(30, 30, 30));
+        assert_eq!(theme.on_info, Color::Rgb(30, 30, 30));
+        assert_eq!(theme.on_selection, Color::Rgb(30, 30, 30));
+        assert_eq!(theme.on_install, Color::Rgb(240, 240, 240));
+        assert_eq!(theme.on_danger, Color::Rgb(30, 30, 30));
+    }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1349,6 +1349,15 @@ mod tests {
     }
 
     #[test]
+    fn terminal_preset_preserves_terminal_default_colors() {
+        let theme = Theme::terminal();
+        let buffer = render(theme, |_| {});
+        let spacer = &buffer[(0, theme::LOGO_HEIGHT)];
+        assert_eq!(spacer.fg, Color::Reset);
+        assert_eq!(spacer.bg, Color::Reset);
+    }
+
+    #[test]
     fn rendered_status_and_badges_use_concrete_theme_pairs() {
         for theme in [Theme::original(), Theme::retro(), Theme::nord()] {
             let error = render(theme, |app| {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -20,6 +20,9 @@ use crate::theme;
 const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn draw(f: &mut Frame, app: &mut App) {
+    let palette = app.theme;
+    f.render_widget(Block::default().style(theme::root(&palette)), f.area());
+
     let header_height = theme::LOGO_HEIGHT; // logo + tabs, no extra spacing
     let show_search_bar = app.mode == AppMode::Search
         || app.input_mode == InputMode::Search
@@ -64,19 +67,20 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     }
 
     if let Some(confirm) = &app.confirm {
-        draw_confirm_dialog(f, confirm);
+        draw_confirm_dialog(f, confirm, &palette);
     }
 
     if app.input_mode == InputMode::VersionInput {
-        draw_version_input_dialog(f, app);
+        draw_version_input_dialog(f, app, &palette);
     }
 
     if app.show_help {
-        draw_help_overlay(f, app);
+        draw_help_overlay(f, app, &palette);
     }
 }
 
 fn draw_header(f: &mut Frame, app: &mut App, area: Rect) {
+    let palette = &app.theme;
     // Split: logo on left (34 chars) | spacing (3 chars) | tabs on right
     let logo_width = 33u16; // 31 word-art + 1 padding each side
     let gap = 4u16;
@@ -93,8 +97,10 @@ fn draw_header(f: &mut Frame, app: &mut App, area: Rect) {
     app.layout.tab_bar = chunks[2];
 
     // Draw pixel-art logo (vertically centered in the area, excluding spacing row)
-    let logo_lines = theme::logo_lines();
-    let logo = Paragraph::new(logo_lines).alignment(Alignment::Center);
+    let logo_lines = theme::logo_lines(palette);
+    let logo = Paragraph::new(logo_lines)
+        .style(theme::root(palette))
+        .alignment(Alignment::Center);
     f.render_widget(logo, chunks[0]);
 
     // Draw tabs vertically centered in the right area
@@ -116,9 +122,9 @@ fn draw_header(f: &mut Frame, app: &mut App, area: Rect) {
         .iter()
         .flat_map(|(mode, label)| {
             let style = if *mode == app.mode {
-                theme::navbar_active()
+                theme::navbar_active(palette)
             } else {
-                theme::navbar_inactive()
+                theme::navbar_inactive(palette)
             };
             let tab_text = format!(" {} ", label);
             let tab_width = UnicodeWidthStr::width(tab_text.as_str()) as u16;
@@ -144,7 +150,7 @@ fn draw_header(f: &mut Frame, app: &mut App, area: Rect) {
         height: 1,
     };
     let version = Paragraph::new(format!("v{APP_VERSION}"))
-        .style(Style::default().fg(theme::TEXT_SECONDARY))
+        .style(theme::secondary(palette))
         .alignment(Alignment::Right);
     f.render_widget(version, version_rect);
 
@@ -152,14 +158,15 @@ fn draw_header(f: &mut Frame, app: &mut App, area: Rect) {
 }
 
 fn draw_search_bar(f: &mut Frame, app: &mut App, area: Rect) {
+    let palette = &app.theme;
     // Store region for mouse clicks
     app.layout.search_bar = area;
 
     let search_style =
         if app.input_mode == InputMode::Search || app.input_mode == InputMode::LocalFilter {
-            Style::default().fg(theme::TEXT_PRIMARY).bg(theme::SURFACE)
+            theme::surface(palette)
         } else {
-            Style::default().fg(theme::TEXT_SECONDARY)
+            theme::secondary(palette)
         };
 
     let (active_text, placeholder) = if app.mode == AppMode::Search {
@@ -204,6 +211,7 @@ fn draw_main_content(f: &mut Frame, app: &mut App, area: Rect) {
 }
 
 fn draw_package_list(f: &mut Frame, app: &mut App, area: Rect) {
+    let palette = &app.theme;
     let is_focused = app.focus == FocusZone::PackageList;
 
     let title = match app.mode {
@@ -253,7 +261,7 @@ fn draw_package_list(f: &mut Frame, app: &mut App, area: Rect) {
     let header = Row::new(
         header_cells
             .iter()
-            .map(|h| Cell::from(h.as_ref()).style(theme::table_header())),
+            .map(|h| Cell::from(h.as_ref()).style(theme::table_header(palette))),
     )
     .height(1);
 
@@ -265,11 +273,11 @@ fn draw_package_list(f: &mut Frame, app: &mut App, area: Rect) {
             let is_selected = i == app.selected;
             let is_marked = app.mode == AppMode::Upgrades && app.selected_packages.contains(&i);
             let style = if is_selected {
-                theme::selected_row()
+                theme::selected_row(palette)
             } else if is_marked {
-                theme::marked_row()
+                theme::marked_row(palette)
             } else {
-                Style::default()
+                theme::root(palette)
             };
 
             let prefix = if app.mode == AppMode::Upgrades {
@@ -289,6 +297,11 @@ fn draw_package_list(f: &mut Frame, app: &mut App, area: Rect) {
             };
 
             let cells: Vec<Cell> = if app.mode == AppMode::Upgrades {
+                let available_style = if is_selected {
+                    theme::selected_row(palette)
+                } else {
+                    theme::success_text(palette)
+                };
                 vec![
                     Cell::from(format!(
                         "{}{}{}",
@@ -298,10 +311,7 @@ fn draw_package_list(f: &mut Frame, app: &mut App, area: Rect) {
                     )),
                     Cell::from(truncate(&pkg.id, 25)),
                     Cell::from(pkg.version.as_str()),
-                    Cell::from(Span::styled(
-                        &pkg.available_version,
-                        Style::default().fg(theme::SUCCESS),
-                    )),
+                    Cell::from(Span::styled(&pkg.available_version, available_style)),
                     Cell::from(pkg.source.as_str()),
                 ]
             } else {
@@ -340,17 +350,23 @@ fn draw_package_list(f: &mut Frame, app: &mut App, area: Rect) {
     };
 
     let border_style = if is_focused {
-        theme::border_focused()
+        theme::border_focused(palette)
     } else {
-        theme::border_unfocused()
+        theme::border_unfocused(palette)
     };
+    let focus_marker = if is_focused { ">" } else { " " };
 
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(border_style)
-        .title(format!(" {} ({}) ", title, app.filtered_packages.len()))
-        .title_style(theme::title())
+        .title(format!(
+            " {focus_marker} {} ({}) ",
+            title,
+            app.filtered_packages.len()
+        ))
+        .title_style(theme::title(palette))
+        .style(theme::root(palette))
         .padding(ratatui::widgets::Padding::top(1));
 
     // Loading / empty state
@@ -393,7 +409,7 @@ fn draw_package_list(f: &mut Frame, app: &mut App, area: Rect) {
     if let Some(msg) = loading_msg {
         let p = Paragraph::new(msg)
             .block(block)
-            .style(Style::default().fg(theme::TEXT_SECONDARY));
+            .style(theme::secondary(palette));
         f.render_widget(p, area);
         return;
     }
@@ -423,6 +439,7 @@ fn draw_package_list(f: &mut Frame, app: &mut App, area: Rect) {
 }
 
 fn draw_detail_panel(f: &mut Frame, app: &mut App, area: Rect) {
+    let palette = &app.theme;
     let is_focused = app.focus == FocusZone::DetailPanel;
 
     let title = if app.detail_loading {
@@ -430,11 +447,13 @@ fn draw_detail_panel(f: &mut Frame, app: &mut App, area: Rect) {
     } else {
         " Package Details ".to_string()
     };
+    let focus_marker = if is_focused { ">" } else { " " };
+    let title = format!(" {focus_marker}{title}");
 
     let border_style = if is_focused {
-        theme::border_focused()
+        theme::border_focused(palette)
     } else {
-        theme::border_unfocused()
+        theme::border_unfocused(palette)
     };
 
     let block = Block::default()
@@ -442,11 +461,12 @@ fn draw_detail_panel(f: &mut Frame, app: &mut App, area: Rect) {
         .border_type(BorderType::Rounded)
         .border_style(border_style)
         .title(title)
-        .title_style(theme::title())
+        .title_style(theme::title(palette))
+        .style(theme::root(palette))
         .padding(ratatui::widgets::Padding::top(1));
 
     if let Some(detail) = &app.detail {
-        let label_style = theme::detail_label();
+        let label_style = theme::detail_label(palette);
 
         let available_version = app
             .selected_package()
@@ -460,7 +480,7 @@ fn draw_detail_panel(f: &mut Frame, app: &mut App, area: Rect) {
             ]),
             Line::from(vec![
                 Span::styled("  ID        ", label_style),
-                Span::styled(&detail.id, Style::default().fg(theme::INFO)),
+                Span::styled(&detail.id, theme::info_text(palette)),
             ]),
             Line::from(vec![
                 Span::styled("  Version   ", label_style),
@@ -473,9 +493,7 @@ fn draw_detail_panel(f: &mut Frame, app: &mut App, area: Rect) {
                 Span::styled("  Available ", label_style),
                 Span::styled(
                     available_version.to_string(),
-                    Style::default()
-                        .fg(theme::SUCCESS)
-                        .add_modifier(Modifier::BOLD),
+                    theme::success_text(palette).add_modifier(Modifier::BOLD),
                 ),
             ]));
         }
@@ -494,7 +512,7 @@ fn draw_detail_panel(f: &mut Frame, app: &mut App, area: Rect) {
         if detail.pin_state.is_pinned() {
             lines.push(Line::from(vec![
                 Span::styled("  Pin       ", label_style),
-                Span::styled("📌 ", Style::default().fg(theme::ACCENT)),
+                Span::styled("📌 ", theme::table_header(palette)),
                 Span::raw(detail.pin_state.label()),
             ]));
         }
@@ -512,9 +530,7 @@ fn draw_detail_panel(f: &mut Frame, app: &mut App, area: Rect) {
                 Span::raw("  "),
                 Span::styled(
                     &detail.homepage,
-                    Style::default()
-                        .fg(theme::INFO)
-                        .add_modifier(Modifier::UNDERLINED),
+                    theme::info_text(palette).add_modifier(Modifier::UNDERLINED),
                 ),
             ]));
         }
@@ -524,12 +540,10 @@ fn draw_detail_panel(f: &mut Frame, app: &mut App, area: Rect) {
                 lines.push(Line::raw(""));
             }
             lines.push(Line::from(vec![
-                Span::styled("  📋 ", Style::default().fg(theme::INFO)),
+                Span::styled("  📋 ", theme::info_text(palette)),
                 Span::styled(
                     &detail.release_notes_url,
-                    Style::default()
-                        .fg(theme::INFO)
-                        .add_modifier(Modifier::UNDERLINED),
+                    theme::info_text(palette).add_modifier(Modifier::UNDERLINED),
                 ),
             ]));
         }
@@ -538,7 +552,7 @@ fn draw_detail_panel(f: &mut Frame, app: &mut App, area: Rect) {
             lines.push(Line::raw(""));
             lines.push(Line::from(Span::styled("  Description", label_style)));
             // Manually word-wrap description to maintain consistent 2-space indent
-            let desc_style = Style::default().fg(theme::TEXT_SECONDARY);
+            let desc_style = theme::secondary(palette);
             let indent = "  ";
             // Available width: area minus borders (2) minus block padding (0 horiz) minus indent (2)
             let max_width = (area.width as usize).saturating_sub(4);
@@ -558,13 +572,13 @@ fn draw_detail_panel(f: &mut Frame, app: &mut App, area: Rect) {
             AppMode::Search => {
                 lines.push(Line::from(vec![
                     Span::raw("  "),
-                    Span::styled(" i ", theme::action_install()),
+                    Span::styled(" i ", theme::action_install(palette)),
                     Span::raw(" Install"),
                 ]));
                 lines.push(Line::raw(""));
                 lines.push(Line::from(vec![
                     Span::raw("  "),
-                    Span::styled(" I ", theme::action_install()),
+                    Span::styled(" I ", theme::action_install(palette)),
                     Span::raw(" Install specific version"),
                 ]));
             }
@@ -572,20 +586,20 @@ fn draw_detail_panel(f: &mut Frame, app: &mut App, area: Rect) {
                 if has_upgrade {
                     lines.push(Line::from(vec![
                         Span::raw("  "),
-                        Span::styled(" u ", theme::action_key()),
+                        Span::styled(" u ", theme::action_key(palette)),
                         Span::raw(" Upgrade"),
                     ]));
                     lines.push(Line::raw(""));
                 }
                 lines.push(Line::from(vec![
                     Span::raw("  "),
-                    Span::styled(" x ", theme::action_danger()),
+                    Span::styled(" x ", theme::action_danger(palette)),
                     Span::raw(" Uninstall"),
                 ]));
                 lines.push(Line::raw(""));
                 lines.push(Line::from(vec![
                     Span::raw("  "),
-                    Span::styled(" p ", theme::action_key()),
+                    Span::styled(" p ", theme::action_key(palette)),
                     Span::raw(if detail.pin_state.is_pinned() {
                         " Remove pin"
                     } else {
@@ -596,31 +610,31 @@ fn draw_detail_panel(f: &mut Frame, app: &mut App, area: Rect) {
             AppMode::Upgrades => {
                 lines.push(Line::from(vec![
                     Span::raw("  "),
-                    Span::styled(" u ", theme::action_key()),
+                    Span::styled(" u ", theme::action_key(palette)),
                     Span::raw(" Upgrade"),
                 ]));
                 lines.push(Line::raw(""));
                 lines.push(Line::from(vec![
                     Span::raw("  "),
-                    Span::styled(" x ", theme::action_danger()),
+                    Span::styled(" x ", theme::action_danger(palette)),
                     Span::raw(" Uninstall"),
                 ]));
                 lines.push(Line::raw(""));
                 lines.push(Line::from(vec![
                     Span::raw("  "),
-                    Span::styled(" Spc ", theme::action_key()),
+                    Span::styled(" Spc ", theme::action_key(palette)),
                     Span::raw(" Select"),
                 ]));
                 lines.push(Line::raw(""));
                 lines.push(Line::from(vec![
                     Span::raw("  "),
-                    Span::styled(" a ", theme::action_key()),
+                    Span::styled(" a ", theme::action_key(palette)),
                     Span::raw(" All"),
                 ]));
                 lines.push(Line::raw(""));
                 lines.push(Line::from(vec![
                     Span::raw("  "),
-                    Span::styled(" p ", theme::action_key()),
+                    Span::styled(" p ", theme::action_key(palette)),
                     Span::raw(if detail.pin_state.is_pinned() {
                         " Remove pin"
                     } else {
@@ -631,7 +645,7 @@ fn draw_detail_panel(f: &mut Frame, app: &mut App, area: Rect) {
                     lines.push(Line::raw(""));
                     lines.push(Line::from(vec![
                         Span::raw("  "),
-                        Span::styled(" U ", theme::action_key()),
+                        Span::styled(" U ", theme::action_key(palette)),
                         Span::raw(format!(" Upgrade {}", app.selected_packages.len())),
                     ]));
                 }
@@ -642,7 +656,7 @@ fn draw_detail_panel(f: &mut Frame, app: &mut App, area: Rect) {
             lines.push(Line::raw(""));
             lines.push(Line::from(vec![
                 Span::raw("  "),
-                Span::styled(" o ", theme::action_key()),
+                Span::styled(" o ", theme::action_key(palette)),
                 Span::raw(" Open homepage"),
             ]));
         }
@@ -650,7 +664,7 @@ fn draw_detail_panel(f: &mut Frame, app: &mut App, area: Rect) {
             lines.push(Line::raw(""));
             lines.push(Line::from(vec![
                 Span::raw("  "),
-                Span::styled(" c ", theme::action_key()),
+                Span::styled(" c ", theme::action_key(palette)),
                 Span::raw(" Open changelog"),
             ]));
         }
@@ -695,12 +709,13 @@ fn draw_detail_panel(f: &mut Frame, app: &mut App, area: Rect) {
         };
         let p = Paragraph::new(msg)
             .block(block)
-            .style(Style::default().fg(theme::TEXT_SECONDARY));
+            .style(theme::secondary(palette));
         f.render_widget(p, area);
     }
 }
 
 fn draw_status_bar(f: &mut Frame, app: &App, area: Rect) {
+    let palette = &app.theme;
     let filter_text = format!(" {} ", app.source_filter);
     let filter_len = UnicodeWidthStr::width(filter_text.as_str()) as u16 + 2; // + padding
     let show_pin_badge = app.mode != AppMode::Search;
@@ -727,30 +742,18 @@ fn draw_status_bar(f: &mut Frame, app: &App, area: Rect) {
 
     // Filter badge
     let filter_style = match app.source_filter {
-        crate::models::SourceFilter::All => {
-            Style::default().fg(theme::TEXT_PRIMARY).bg(theme::SURFACE)
-        }
-        crate::models::SourceFilter::Winget => {
-            Style::default().fg(theme::TEXT_ON_ACCENT).bg(theme::INFO)
-        }
-        crate::models::SourceFilter::MsStore => Style::default()
-            .fg(theme::TEXT_ON_ACCENT)
-            .bg(theme::SELECTION),
+        crate::models::SourceFilter::All => theme::surface(palette),
+        crate::models::SourceFilter::Winget => theme::source_winget(palette),
+        crate::models::SourceFilter::MsStore => theme::source_msstore(palette),
     };
     let filter_badge = Paragraph::new(filter_text).style(filter_style);
     f.render_widget(filter_badge, chunks[0]);
 
     if show_pin_badge {
         let pin_style = match app.pin_filter {
-            crate::models::PinFilter::All => {
-                Style::default().fg(theme::TEXT_PRIMARY).bg(theme::SURFACE)
-            }
-            crate::models::PinFilter::PinnedOnly => {
-                Style::default().fg(theme::TEXT_ON_ACCENT).bg(theme::ACCENT)
-            }
-            crate::models::PinFilter::UnpinnedOnly => {
-                Style::default().fg(theme::TEXT_ON_ACCENT).bg(theme::INFO)
-            }
+            crate::models::PinFilter::All => theme::surface(palette),
+            crate::models::PinFilter::PinnedOnly => theme::navbar_active(palette),
+            crate::models::PinFilter::UnpinnedOnly => theme::source_winget(palette),
         };
         let pin_badge = Paragraph::new(pin_text).style(pin_style);
         f.render_widget(pin_badge, chunks[1]);
@@ -764,21 +767,19 @@ fn draw_status_bar(f: &mut Frame, app: &App, area: Rect) {
     };
     let status_style =
         if app.status_message.contains("failed") || app.status_message.contains("Error") {
-            theme::status_error()
+            theme::status_error(palette)
         } else if app.loading {
-            theme::status_loading()
+            theme::status_loading(palette)
         } else {
-            theme::status_normal()
+            theme::status_normal(palette)
         };
     let status = Paragraph::new(status_text).style(status_style);
     f.render_widget(status, chunks[2]);
 
     // Global hotkey badges
-    let key_style = theme::action_key();
+    let key_style = theme::action_key(palette);
     let sep = Span::raw(" ");
-    let label_style = Style::default()
-        .fg(theme::TEXT_SECONDARY)
-        .bg(theme::SURFACE);
+    let label_style = theme::surface_secondary(palette);
 
     let hotkeys = match app.input_mode {
         InputMode::Search => Line::from(vec![
@@ -836,26 +837,22 @@ fn draw_status_bar(f: &mut Frame, app: &App, area: Rect) {
     };
 
     let hints = Paragraph::new(hotkeys)
-        .style(Style::default().bg(theme::SURFACE))
+        .style(theme::surface(palette))
         .alignment(Alignment::Right);
     f.render_widget(hints, chunks[3]);
 }
 
-fn draw_confirm_dialog(f: &mut Frame, confirm: &ConfirmDialog) {
+fn draw_confirm_dialog(f: &mut Frame, confirm: &ConfirmDialog, palette: &theme::Theme) {
     let area = centered_rect(50, 20, f.area());
     f.render_widget(Clear, area);
 
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .border_style(theme::border_focused())
+        .border_style(Style::default().fg(palette.accent).bg(palette.surface))
         .title(" Confirm ")
-        .title_style(
-            Style::default()
-                .fg(theme::ACCENT)
-                .add_modifier(Modifier::BOLD),
-        )
-        .style(Style::default().bg(theme::SURFACE));
+        .title_style(theme::help_section(palette))
+        .style(theme::surface(palette));
 
     let lines = vec![
         Line::raw(""),
@@ -863,20 +860,21 @@ fn draw_confirm_dialog(f: &mut Frame, confirm: &ConfirmDialog) {
         Line::raw(""),
         Line::from(vec![
             Span::raw("  "),
-            Span::styled(" y ", theme::action_confirm()),
+            Span::styled(" y ", theme::action_confirm(palette)),
             Span::raw(" Yes   "),
-            Span::styled(" n ", theme::action_danger()),
+            Span::styled(" n ", theme::action_danger(palette)),
             Span::raw(" No"),
         ]),
     ];
 
     let p = Paragraph::new(lines)
         .block(block)
+        .style(theme::surface(palette))
         .wrap(Wrap { trim: false });
     f.render_widget(p, area);
 }
 
-fn draw_version_input_dialog(f: &mut Frame, app: &App) {
+fn draw_version_input_dialog(f: &mut Frame, app: &App, palette: &theme::Theme) {
     let area = centered_rect(55, 25, f.area());
     f.render_widget(Clear, area);
 
@@ -889,15 +887,14 @@ fn draw_version_input_dialog(f: &mut Frame, app: &App) {
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .title(" 📦 Install Specific Version ")
-        .title_style(
-            Style::default()
-                .fg(theme::ACCENT)
-                .add_modifier(Modifier::BOLD),
-        )
-        .border_style(theme::border_focused())
-        .style(Style::default().bg(theme::SURFACE));
+        .title_style(theme::help_section(palette))
+        .border_style(Style::default().fg(palette.accent).bg(palette.surface))
+        .style(theme::surface(palette));
 
-    let label_style = theme::detail_label();
+    let label_style = Style::default()
+        .fg(palette.accent)
+        .bg(palette.surface)
+        .add_modifier(Modifier::BOLD);
 
     let lines = vec![
         Line::raw(""),
@@ -910,24 +907,23 @@ fn draw_version_input_dialog(f: &mut Frame, app: &App) {
             Span::raw("  Version: "),
             Span::styled(
                 &app.version_input,
-                Style::default()
-                    .fg(theme::TEXT_PRIMARY)
-                    .add_modifier(Modifier::BOLD),
+                theme::surface(palette).add_modifier(Modifier::BOLD),
             ),
-            Span::styled("█", Style::default().fg(theme::ACCENT)),
+            Span::styled("█", Style::default().fg(palette.accent).bg(palette.surface)),
         ]),
         Line::raw(""),
         Line::from(vec![
             Span::raw("  "),
-            Span::styled(" Enter ", theme::action_confirm()),
+            Span::styled(" Enter ", theme::action_confirm(palette)),
             Span::raw(" Confirm   "),
-            Span::styled(" Esc ", theme::action_danger()),
+            Span::styled(" Esc ", theme::action_danger(palette)),
             Span::raw(" Cancel"),
         ]),
     ];
 
     let p = Paragraph::new(lines)
         .block(block)
+        .style(theme::surface(palette))
         .wrap(Wrap { trim: false });
     f.render_widget(p, area);
 
@@ -937,26 +933,22 @@ fn draw_version_input_dialog(f: &mut Frame, app: &App) {
     f.set_cursor_position((cursor_x, cursor_y));
 }
 
-fn draw_help_overlay(f: &mut Frame, app: &mut App) {
+fn draw_help_overlay(f: &mut Frame, app: &mut App, palette: &theme::Theme) {
     let area = centered_rect(60, 70, f.area());
     f.render_widget(Clear, area);
 
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .border_style(theme::border_focused())
+        .border_style(Style::default().fg(palette.accent).bg(palette.surface))
         .title(format!(
             " Help -- winget-tui v{APP_VERSION} -- Keybindings  ↑↓ to scroll "
         ))
-        .title_style(
-            Style::default()
-                .fg(theme::ACCENT)
-                .add_modifier(Modifier::BOLD),
-        )
-        .style(Style::default().bg(theme::SURFACE));
+        .title_style(theme::help_section(palette))
+        .style(theme::surface(palette));
 
-    let section = theme::help_section();
-    let key = theme::help_key();
+    let section = theme::help_section(palette);
+    let key = theme::help_key(palette);
 
     let help_text = vec![
         Line::raw(""),
@@ -1089,6 +1081,7 @@ fn draw_help_overlay(f: &mut Frame, app: &mut App) {
 
     let p = Paragraph::new(help_text)
         .block(block)
+        .style(theme::surface(palette))
         .wrap(Wrap { trim: false })
         .scroll((app.help_scroll, 0));
     f.render_widget(p, area);
@@ -1227,8 +1220,210 @@ fn word_wrap(text: &str, max_width: usize) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use anyhow::Result;
+    use async_trait::async_trait;
+    use ratatui::{backend::TestBackend, buffer::Buffer, style::Color, Terminal};
+
     use super::*;
-    use crate::models::{SortDir, SortField};
+    use crate::backend::WingetBackend;
+    use crate::models::{
+        Operation, Package, PackageDetail, PackagePin, SortDir, SortField, Source, SourceFilter,
+    };
+    use crate::theme::Theme;
+
+    struct NoopBackend;
+
+    #[async_trait]
+    impl WingetBackend for NoopBackend {
+        async fn search(&self, _: &str, _: Option<&str>) -> Result<Vec<Package>> {
+            Ok(Vec::new())
+        }
+
+        async fn list_installed(&self, _: Option<&str>) -> Result<Vec<Package>> {
+            Ok(Vec::new())
+        }
+
+        async fn list_upgrades(&self, _: Option<&str>) -> Result<Vec<Package>> {
+            Ok(Vec::new())
+        }
+
+        async fn show(&self, _: &str) -> Result<PackageDetail> {
+            Ok(PackageDetail::default())
+        }
+
+        async fn install(&self, _: &str, _: Option<&str>) -> Result<String> {
+            Ok(String::new())
+        }
+
+        async fn uninstall(&self, _: &str) -> Result<String> {
+            Ok(String::new())
+        }
+
+        async fn upgrade(&self, _: &str) -> Result<String> {
+            Ok(String::new())
+        }
+
+        async fn list_pins(&self) -> Result<Vec<PackagePin>> {
+            Ok(Vec::new())
+        }
+
+        async fn pin(&self, _: &str) -> Result<String> {
+            Ok(String::new())
+        }
+
+        async fn unpin(&self, _: &str) -> Result<String> {
+            Ok(String::new())
+        }
+
+        async fn list_sources(&self) -> Result<Vec<Source>> {
+            Ok(Vec::new())
+        }
+    }
+
+    fn render(theme: Theme, configure: impl FnOnce(&mut App)) -> Buffer {
+        let mut app = App::new(Arc::new(NoopBackend), crate::config::Config::default());
+        app.theme = theme;
+        configure(&mut app);
+
+        let backend = TestBackend::new(160, 40);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        terminal
+            .draw(|frame| draw(frame, &mut app))
+            .expect("render succeeds");
+        terminal.backend().buffer().clone()
+    }
+
+    fn find_text(buffer: &Buffer, needle: &str) -> (u16, u16) {
+        for y in 0..buffer.area().height {
+            for start_x in 0..buffer.area().width {
+                let suffix: String = (start_x..buffer.area().width)
+                    .map(|x| buffer[(x, y)].symbol())
+                    .collect();
+                if suffix.starts_with(needle) {
+                    return (start_x, y);
+                }
+            }
+        }
+        panic!("did not find {needle:?} in rendered buffer");
+    }
+
+    fn is_wide_continuation(buffer: &Buffer, index: usize) -> bool {
+        let width = buffer.area().width as usize;
+        let x = index % width;
+        x > 0 && UnicodeWidthStr::width(buffer.content()[index - 1].symbol()) > 1
+    }
+
+    fn assert_no_reset_cells(buffer: &Buffer, area: Rect) {
+        for y in area.y..area.y + area.height {
+            for x in area.x..area.x + area.width {
+                let index = y as usize * buffer.area().width as usize + x as usize;
+                if is_wide_continuation(buffer, index) {
+                    continue;
+                }
+                let cell = &buffer[(x, y)];
+                assert_ne!(cell.fg, Color::Reset, "reset foreground at ({x}, {y})");
+                assert_ne!(cell.bg, Color::Reset, "reset background at ({x}, {y})");
+            }
+        }
+    }
+
+    fn assert_text_style(buffer: &Buffer, needle: &str, foreground: Color, background: Color) {
+        let (x, y) = find_text(buffer, needle);
+        let cell = &buffer[(x, y)];
+        assert_eq!(cell.fg, foreground, "{needle:?} foreground");
+        assert_eq!(cell.bg, background, "{needle:?} background");
+    }
+
+    #[test]
+    fn every_preset_owns_the_rendered_root_colors() {
+        for theme in [Theme::original(), Theme::retro(), Theme::nord()] {
+            let buffer = render(theme, |_| {});
+            assert_no_reset_cells(&buffer, *buffer.area());
+
+            let spacer = &buffer[(0, theme::LOGO_HEIGHT)];
+            assert_eq!(spacer.fg, theme.text_primary);
+            assert_eq!(spacer.bg, theme.background);
+        }
+    }
+
+    #[test]
+    fn rendered_status_and_badges_use_concrete_theme_pairs() {
+        for theme in [Theme::original(), Theme::retro(), Theme::nord()] {
+            let error = render(theme, |app| {
+                app.status_message = "Error: test".to_string();
+            });
+            assert_text_style(&error, "Error: test", theme.error, theme.surface);
+
+            let msstore = render(theme, |app| {
+                app.source_filter = SourceFilter::MsStore;
+            });
+            assert_text_style(&msstore, "msstore", theme.on_selection, theme.selection);
+        }
+    }
+
+    #[test]
+    fn overlays_repaint_cells_after_clear() {
+        for theme in [Theme::original(), Theme::retro(), Theme::nord()] {
+            let confirm = render(theme, |app| {
+                app.confirm = Some(ConfirmDialog {
+                    message: "Proceed with operation?".to_string(),
+                    operation: Operation::Upgrade {
+                        id: "Example.Package".to_string(),
+                    },
+                });
+            });
+            assert_text_style(
+                &confirm,
+                "Proceed with operation?",
+                theme.text_primary,
+                theme.surface,
+            );
+            assert_no_reset_cells(&confirm, centered_rect(50, 20, *confirm.area()));
+
+            let help = render(theme, |app| app.show_help = true);
+            assert_text_style(&help, "Move up / down", theme.text_primary, theme.surface);
+            assert_no_reset_cells(&help, centered_rect(60, 70, *help.area()));
+
+            let version = render(theme, |app| {
+                app.input_mode = InputMode::VersionInput;
+                app.version_input = "1.2.3".to_string();
+            });
+            assert_text_style(&version, "1.2.3", theme.text_primary, theme.surface);
+            assert_no_reset_cells(&version, centered_rect(55, 25, *version.area()));
+        }
+    }
+
+    #[test]
+    fn selected_upgrade_row_keeps_a_continuous_selection_background() {
+        for theme in [Theme::original(), Theme::retro(), Theme::nord()] {
+            let buffer = render(theme, |app| {
+                app.mode = AppMode::Upgrades;
+                app.packages = vec![Package {
+                    name: "Example Package".to_string(),
+                    id: "Example.Package".to_string(),
+                    version: "1.0".to_string(),
+                    available_version: "2.0".to_string(),
+                    source: "winget".to_string(),
+                    pin_state: Default::default(),
+                }];
+                app.filtered_packages = app.packages.clone();
+            });
+            assert_text_style(&buffer, "2.0", theme.on_accent, theme.accent);
+        }
+    }
+
+    #[test]
+    fn focused_panel_has_a_non_color_marker() {
+        let list_focused = render(Theme::original(), |_| {});
+        find_text(&list_focused, "> Installed");
+
+        let detail_focused = render(Theme::original(), |app| {
+            app.focus = FocusZone::DetailPanel;
+        });
+        find_text(&detail_focused, "> Package Details");
+    }
 
     #[test]
     fn truncate_ascii_within_limit() {


### PR DESCRIPTION
## Summary

This is a clean reimplementation of theme support from the current `main` branch and is intended to replace #365. 

- adds configurable `original`, `retro`, and `nord` theme presets
- introduces semantic foreground/background roles and centralized style helpers
- applies the selected theme across the complete Ratatui UI
- paints the root frame and cleared overlays with explicit foreground and background colors so contrast does not depend on terminal defaults
- adds a non-color `>` marker to reinforce package-list and detail-panel focus
- documents the `theme` startup configuration option

## Configuration

```toml
theme = "retro" # original | retro | nord
```

Theme names are parsed case-insensitively. Missing or unknown values use the Original preset. Theme selection is applied at startup.

## Accessibility verification

The implementation uses semantic color pairs instead of sharing one foreground across unrelated accent, success, information, selection, install, and danger backgrounds.

Automated verification includes:

- WCAG 2.2 relative-luminance calculation using the `0.04045` breakpoint
- minimum `4.5:1` contrast for normal text pairs
- minimum `3:1` contrast for essential non-text focus and boundary indicators
- concrete checks for root and surface text, secondary text, errors, links, selected rows, source badges, install/confirm/danger actions, and focused/unfocused borders
- Ratatui `TestBackend` assertions for all three presets
- rendered-cell checks that the application-owned root and overlay regions do not visibly fall back to terminal reset colors
- confirmation, version-input, and help-overlay checks after `Clear`
- regression coverage for continuous selected-row backgrounds in the Upgrades view
- a non-color focus-marker assertion

The Original preset retains the existing palette where possible. Accessibility-driven exceptions are limited to brighter error/danger colors and adjusted install/danger button foregrounds so their concrete pairs meet the contrast baseline.

## PR #365 feedback addressed

- root `Theme.background` is now painted across the full frame
- contrast tests validate actual foreground/background usage, not unused palette fields
- MsStore and Winget badge pairs are palette-specific and tested
- Nord error text meets the text contrast floor
- install styling is palette-driven
- inline-commented configuration values are covered
- Original palette differences are explicitly identified
- normal repository CI checks are expected before this draft is marked ready

## Tests

Run locally against this branch:

- `cargo check --locked --all-targets`
- `cargo fmt -- --check`
- `cargo test --locked` — 385 unit tests and 1 Windows integration test passed
- `cargo clippy --locked -- -D warnings`